### PR TITLE
Fix/remove lambda fixed region

### DIFF
--- a/be_wmg_aws/audience_rules/index.mjs
+++ b/be_wmg_aws/audience_rules/index.mjs
@@ -15,7 +15,6 @@ const db_secret_arn = process.env.DB_SECRET_ARN;
 const db_name = process.env.DB_NAME;
 let db_pass;
 
-AWS.config.update({ region: 'sa-east-1' });
 export const lambdaHandler = async (event, context) => {
     const httpMethod = event.httpMethod;
 

--- a/be_wmg_aws/campaigns_performance/index.mjs
+++ b/be_wmg_aws/campaigns_performance/index.mjs
@@ -14,7 +14,6 @@ const db_secret_arn = process.env.DB_SECRET_ARN;
 const db_name = process.env.DB_NAME;
 let db_pass;
 
-AWS.config.update({ region: 'sa-east-1' });
 const s3 = new AWS.S3();
 
 export const lambdaHandler = async (event, context) => {

--- a/be_wmg_aws/db_init/index.mjs
+++ b/be_wmg_aws/db_init/index.mjs
@@ -15,7 +15,6 @@ const db_secret_arn = process.env.DB_SECRET_ARN;
 const db_name = process.env.DB_NAME;
 let db_pass;
 
-AWS.config.update({ region: 'sa-east-1' });
 export const lambdaHandler = async (event, context) => {
   const responseData = {};
   let responseStatus = 'SUCCESS';

--- a/be_wmg_aws/events/index.mjs
+++ b/be_wmg_aws/events/index.mjs
@@ -15,7 +15,6 @@ const db_secret_arn = process.env.DB_SECRET_ARN;
 const db_name = process.env.DB_NAME;
 let db_pass;
 
-AWS.config.update({ region: 'sa-east-1' });
 export const lambdaHandler = async (event, context) => {
     const httpMethod = event.httpMethod;
 

--- a/be_wmg_aws/lift_studies/utils/data_utils.py
+++ b/be_wmg_aws/lift_studies/utils/data_utils.py
@@ -12,7 +12,7 @@ class LiftS3Handler:
     """
 
     def __init__(self):
-        self.region = os.environ['AWS_REGION']
+        self.region = os.environ["AWS_REGION"]  # noqa: F821
         self.client = boto3.client("s3", region_name=self.region)
 
     def read_file(self, bucket: str, file_key: str):
@@ -98,7 +98,7 @@ class LiftDatabaseHandler:
         """
         try:
             print("Getting password")
-            client = boto3.client("secretsmanager", region_name=self.region)
+            client = boto3.client("secretsmanager", region_name=self.region)  # noqa: F821
             data = client.get_secret_value(SecretId=db_secret_arn)
             print("Parsing password")
             if "SecretString" in data:

--- a/be_wmg_aws/lift_studies/utils/data_utils.py
+++ b/be_wmg_aws/lift_studies/utils/data_utils.py
@@ -12,7 +12,8 @@ class LiftS3Handler:
     """
 
     def __init__(self):
-        self.client = boto3.client("s3", region_name="sa-east-1")
+        self.region = os.environ['AWS_REGION']
+        self.client = boto3.client("s3", region_name=self.region)
 
     def read_file(self, bucket: str, file_key: str):
         """
@@ -97,7 +98,7 @@ class LiftDatabaseHandler:
         """
         try:
             print("Getting password")
-            client = boto3.client("secretsmanager", region_name="sa-east-1")
+            client = boto3.client("secretsmanager", region_name=self.region)
             data = client.get_secret_value(SecretId=db_secret_arn)
             print("Parsing password")
             if "SecretString" in data:

--- a/be_wmg_aws/manage_keywords/index.mjs
+++ b/be_wmg_aws/manage_keywords/index.mjs
@@ -14,7 +14,6 @@ const db_secret_arn = process.env.DB_SECRET_ARN;
 const db_name = process.env.DB_NAME;
 let db_pass;
 
-AWS.config.update({ region: 'sa-east-1' });
 export const lambdaHandler = async (event, context) => {
     const httpMethod = event.httpMethod;
     const { id: keyword_id } = event.pathParameters || {};

--- a/be_wmg_aws/process_signals/index.mjs
+++ b/be_wmg_aws/process_signals/index.mjs
@@ -14,7 +14,6 @@ const dbSecretArn = process.env.DB_SECRET_ARN;
 const db_name = process.env.DB_NAME;
 let dbPass;
 
-AWS.config.update({ region: 'sa-east-1' });
 export const lambdaHandler = async (event, context) => {
     let connection;
     try {

--- a/be_wmg_aws/router/index.mjs
+++ b/be_wmg_aws/router/index.mjs
@@ -16,7 +16,6 @@ const dbSecretArn = process.env.DB_SECRET_ARN;
 const db_name = process.env.DB_NAME;
 let dbPass;
 
-AWS.config.update({ region: 'sa-east-1' });
 const sqs = new AWS.SQS();
 export const lambdaHandler = async (event, context) => {
     let connection;


### PR DESCRIPTION
Relates to: #5 

## Pull Request Description

### Objective
This pull request aims to enhance the portability and flexibility of the project's Lambdas by enabling them to be deployed and operated across different AWS regions without relying on fixed region configurations.

### Proposed Changes
- **For Node.js Lambdas:**
  - Refactored handlers (`lambdaHandler`) to dynamically utilize `process.env.AWS_REGION` for AWS region configuration.
  - Removed hardcoded AWS region (`sa-east-1`) settings from Lambdas such as `audience_rules`, `campaigns_performance`, `db_init`, `events`, `manage_keywords`, `process_signals`, `router`, `audience_rules`.
  
- **For Python Lambdas:**
  - Updated Python handlers (`LiftS3Handler`, `LiftDatabaseHandler`) to dynamically fetch AWS region using `os.environ['AWS_REGION']` or `boto3.Session().region_name`.
  - Eliminated fixed AWS region configurations in the Python handlers.

### Benefits
- Significantly improves project portability by supporting deployments in various AWS regions.
- Reduces issues related to fixed region configurations in AWS services.

### Tests Performed
- Verified correct operation of Lambdas in different AWS regions (`us-east-1`, `us-east-2`).
- Conducted integration tests to ensure proper access to AWS services (e.g., S3, Secrets Manager) post updates.

### References and Resources
- [AWS Lambda Documentation - Environment Variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)
- [AWS SDK for Python Documentation - Region Configuration](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/regions.html)

### Contact
Please feel free to review and provide feedback on this pull request. We welcome any suggestions or improvements to ensure the quality and efficiency of our deployments across diverse AWS environments.
